### PR TITLE
cli: Untrack changes to tuture.yml and related commits

### DIFF
--- a/collapse.js
+++ b/collapse.js
@@ -1,9 +1,0 @@
-/**
- * This module contains filename patterns that shoule be collapsed in renderer.
- */
-
-module.exports = [
-  '.gitignore',
-  'package-lock.json',
-  'yarn.lock',
-];


### PR DESCRIPTION
Resolves #19.

* Commits with messages starting with 'tuture:' will not be tracked
* Changes to tuture.yml itself will not be checked